### PR TITLE
Cancel in-progress password prompt when another auth method succeeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 name = "pam-any"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "pam-bindings",
  "pam-client2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ pam-bindings = { version = "0.2.1", package = "pam-bindings" }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 pam-client2 = { version = "0.5.5", default-features = false }
+libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,22 +60,154 @@ struct Req {
     str: String,
 }
 
+fn dup_fd(fd: libc::c_int) -> Option<libc::c_int> {
+    let fd = unsafe { libc::dup(fd) };
+    if fd >= 0 { Some(fd) } else { None }
+}
+
+fn read_password_interruptible(tty_fd: libc::c_int, notify_fd: libc::c_int, prompt: &str) -> Option<CString> {
+    unsafe {
+        libc::write(
+            tty_fd,
+            prompt.as_ptr() as *const libc::c_void,
+            prompt.len(),
+        );
+
+        let mut orig: libc::termios = std::mem::zeroed();
+        if libc::tcgetattr(tty_fd, &mut orig) != 0 {
+            return None;
+        }
+
+        // ECHO/ICANON off for raw single-byte reads; ISIG off so Ctrl-C is byte 0x03, not a real SIGINT.
+        let mut raw = orig;
+        raw.c_lflag &= !(libc::ECHO | libc::ICANON | libc::ISIG);
+        raw.c_cc[libc::VMIN] = 1;
+        raw.c_cc[libc::VTIME] = 0;
+        if libc::tcsetattr(tty_fd, libc::TCSANOW, &raw) != 0 {
+            // Couldn't disable echo — bail out rather than risk echoing the password
+            return None;
+        }
+
+        let nfds = tty_fd.max(notify_fd) + 1;
+        let mut input: Vec<u8> = Vec::new();
+        let result;
+
+        'read: loop {
+            let mut rfds: libc::fd_set = std::mem::zeroed();
+            libc::FD_ZERO(&mut rfds);
+            libc::FD_SET(tty_fd, &mut rfds);
+            libc::FD_SET(notify_fd, &mut rfds);
+
+            if libc::select(
+                nfds,
+                &mut rfds,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            ) <= 0
+            {
+                result = None;
+                break;
+            }
+
+            if libc::FD_ISSET(notify_fd, &rfds) {
+                // Another auth method succeeded — erase the prompt line
+                let clear = b"\r\x1b[2K";
+                libc::write(tty_fd, clear.as_ptr() as *const libc::c_void, clear.len());
+                // Drain the pipe so it doesn't fire again
+                let mut drain = [0u8; 64];
+                let _ = libc::read(notify_fd, drain.as_mut_ptr() as *mut libc::c_void, drain.len());
+                result = None;
+                break;
+            }
+
+            if libc::FD_ISSET(tty_fd, &rfds) {
+                let mut b = 0u8;
+                if libc::read(tty_fd, &mut b as *mut u8 as *mut libc::c_void, 1) <= 0 {
+                    result = None;
+                    break;
+                }
+                match b {
+                    b'\n' | b'\r' => {
+                        libc::write(tty_fd, b"\n".as_ptr() as *const libc::c_void, 1);
+                        result = CString::new(input).ok();
+                        break 'read;
+                    }
+                    0x7f | 0x08 => {
+                        input.pop(); // backspace / DEL
+                    }
+                    0x03 | 0x04 => {
+                        result = None; // Ctrl-C / Ctrl-D
+                        break;
+                    }
+                    c => input.push(c),
+                }
+            }
+        }
+
+        libc::tcsetattr(tty_fd, libc::TCSANOW, &orig);
+        result
+    }
+}
+
+// Closes on every return path, including early pam_try! exits.
+struct FdGuard([Option<libc::c_int>; 2]);
+impl Drop for FdGuard {
+    fn drop(&mut self) {
+        for fd in self.0.into_iter().flatten() {
+            unsafe {
+                libc::close(fd);
+            }
+        }
+    }
+}
+
 struct PamAny;
 pam_bindings::pam_hooks!(PamAny);
 impl PamHooks for PamAny {
     fn sm_authenticate(pamh: &mut PamHandle, args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+        // A pipe write after its reader already closed must not kill the host process via the default SIGPIPE disposition.
+        unsafe {
+            libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+        }
+
         let arg_string = args
             .iter()
             .map(|s| s.to_str().unwrap())
             .collect::<Vec<_>>()
             .join(" ");
-        // println!("Input: {}", arg_string);
         let input = pam_try!(serde_json::from_str::<Input>(&arg_string).map_err(|_e| PAM_AUTH_ERR));
-        // println!("Input: {:#?}", input);
 
         let conv = pam_try!(pam_try!(pamh.get_item::<Conv>()).ok_or(PAM_AUTH_ERR));
         let user = Arc::new(pam_try!(pamh.get_user(None)));
 
+        let prompt = format!(
+            "{}: ",
+            input.modules.values().cloned().collect::<Vec<_>>().join(" or ")
+        );
+
+        // Falls back to conv.send if /dev/tty is unavailable (e.g. non-interactive sessions).
+        let tty_fd: Option<libc::c_int> = unsafe {
+            let fd = libc::open(b"/dev/tty\0".as_ptr() as *const libc::c_char, libc::O_RDWR | libc::O_CLOEXEC);
+            if fd >= 0 { Some(fd) } else { None }
+        };
+
+        // Notification pipe: each thread gets a dup'd write end. Writing to it wakes
+        // the main thread out of select() when a result arrives.
+        let (notify_r, notify_w): (Option<libc::c_int>, Option<libc::c_int>) =
+            if tty_fd.is_some() {
+                let mut fds = [-1i32; 2];
+                if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) } == 0 {
+                    (Some(fds[0]), Some(fds[1]))
+                } else {
+                    (None, None)
+                }
+            } else {
+                (None, None)
+            };
+        let _fd_guard = FdGuard([tty_fd, notify_r]);
+
+        let mode = input.mode;
         let (ref msg_tx, msg_rx) = std::sync::mpsc::channel();
         let channels = input
             .modules
@@ -85,10 +217,30 @@ impl PamHooks for PamAny {
                 let main_thread = thread::current();
                 let msg_tx = msg_tx.clone();
 
+                // Each thread owns a dup'd copy of the write end so it can signal independently
+                let thread_notify_w: Option<libc::c_int> = notify_w.and_then(dup_fd);
+
                 let (req_tx, req_rx) = std::sync::mpsc::sync_channel(1);
                 let (res_tx, res_rx) = std::sync::mpsc::sync_channel(1);
                 let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
                 thread::spawn(move || {
+                    // Only signals when this result decides the overall outcome, so a fast-failing service can't cancel a still-running one's prompt.
+                    let pipe_signal = |ok: bool, fd: Option<libc::c_int>| {
+                        let should_write = match mode {
+                            Mode::One => ok,
+                            Mode::All => !ok,
+                        };
+                        if let Some(fd) = fd {
+                            unsafe {
+                                if should_write {
+                                    libc::write(fd, b"x".as_ptr() as *const libc::c_void, 1);
+                                }
+                                libc::close(fd);
+                            }
+                        }
+                        main_thread.unpark();
+                    };
+
                     let mut context = match Context::new(
                         &service,
                         Some(&user),
@@ -104,35 +256,39 @@ impl PamHooks for PamAny {
                         Ok(context) => context,
                         Err(e) => {
                             let _ = result_tx.send(Err(e));
-                            main_thread.unpark();
+                            pipe_signal(false, thread_notify_w);
                             return;
                         }
                     };
                     let result = context.authenticate(Flag::empty());
+                    let ok = result.is_ok();
                     let _ = result_tx.send(result);
-                    main_thread.unpark();
+                    pipe_signal(ok, thread_notify_w);
                 });
                 (req_rx, res_tx, result_rx)
             })
             .collect::<Box<[_]>>();
+
+        // Close the master write end — threads own their dup'd copies.
+        // Once all threads finish and close their copies, notify_r becomes readable with EOF.
+        if let Some(w) = notify_w {
+            unsafe { libc::close(w); }
+        }
+
         // If mode is One we count fails to know if all failed
         // If mode is All we count successes to know if all succeeded
         let mut count = 0;
+        let mut prompt_responded = false;
         loop {
             let mut nothing_to_process = true;
 
-            // Print any messages first
-            while let Ok(msg) = msg_rx.try_recv() {
-                nothing_to_process = false;
-                pam_try!(conv.send(msg._type.style(), &msg.msg));
-            }
-
-            // Process results
+            // Check results first — a success here must not be delayed by pending messages
             for result in channels
                 .iter()
                 .filter_map(|(_, _, result_rx)| result_rx.try_recv().ok())
             {
                 nothing_to_process = false;
+                prompt_responded = false;
                 match input.mode {
                     Mode::One => {
                         if result.is_ok() {
@@ -157,21 +313,38 @@ impl PamHooks for PamAny {
                 }
             }
 
-            // Handle prompts, prioritizing the prompts in order of services as they're listed in the input
-            if let Some((req, res_tx)) = channels.iter().find_map(|(req_rx, res_tx, _)| {
-                if let Ok(req) = req_rx.try_recv() {
-                    nothing_to_process = false;
-                    Some((req, res_tx))
-                } else {
-                    None
+            // Drain all sub-service messages silently — text_info is redundant since the
+            // combined prompt already describes every available method, and error_msg is
+            // handled by the outer PAM stack (pam_faillock, sudo, etc.)
+            while msg_rx.try_recv().is_ok() {
+                nothing_to_process = false;
+            }
+
+            if !prompt_responded {
+                if let Some((req, res_tx)) = channels.iter().find_map(|(req_rx, res_tx, _)| {
+                    if let Ok(req) = req_rx.try_recv() {
+                        nothing_to_process = false;
+                        Some((req, res_tx))
+                    } else {
+                        None
+                    }
+                }) {
+                    let response = match (&req._type, tty_fd, notify_r) {
+                        // Echo-off: bypass conv.send, read from tty with select() so another
+                        // method's success can interrupt the read without waiting for Enter
+                        (PromptType::EchoOff, Some(tty), Some(nfd)) => {
+                            read_password_interruptible(tty, nfd, &prompt)
+                        }
+                        // YesNo or no tty: fall back to PAM conversation (blocking)
+                        _ => pam_try!(conv.send(req._type.style(), &prompt)),
+                    };
+                    let _ = res_tx.send(response);
+                    prompt_responded = true;
                 }
-            }) {
-                let response = pam_try!(conv.send(req._type.style(), &req.str));
-                let _ = res_tx.send(response);
             }
 
             if nothing_to_process {
-                // Wait until there is something to process (this (main) thread will be unparked by another thread)
+                // Wait until a thread unparks us (new result, message, or prompt ready)
                 thread::park();
             }
         }
@@ -191,6 +364,11 @@ impl PamAnyConversationHandler<'_> {
     fn format_msg(&self, msg: &str) -> String {
         format!("[{}] {}", self.service_display_name, msg)
     }
+
+    fn send_msg(&self, _type: MsgType, msg: String) {
+        let _ = self.msg_tx.send(Msg { _type, msg });
+        self.main_thread.unpark();
+    }
 }
 
 impl<'a> ConversationHandler for PamAnyConversationHandler<'a> {
@@ -209,7 +387,7 @@ impl<'a> ConversationHandler for PamAnyConversationHandler<'a> {
         self.req_tx
             .send(Req {
                 _type: PromptType::EchoOff,
-                str: self.format_msg(prompt),
+                str: prompt.to_string(),
             })
             .map_err(|_| ErrorCode::CONV_ERR)?;
         self.main_thread.unpark();
@@ -226,7 +404,7 @@ impl<'a> ConversationHandler for PamAnyConversationHandler<'a> {
         self.req_tx
             .send(Req {
                 _type: PromptType::YesNo,
-                str: self.format_msg(prompt),
+                str: prompt.to_string(),
             })
             .map_err(|_| ErrorCode::CONV_ERR)?;
         self.main_thread.unpark();
@@ -242,21 +420,13 @@ impl<'a> ConversationHandler for PamAnyConversationHandler<'a> {
 
     fn text_info(&mut self, msg: &CStr) {
         if let Ok(msg) = msg.to_str() {
-            let _ = self.msg_tx.send(Msg {
-                _type: MsgType::Info,
-                msg: self.format_msg(msg),
-            });
-            self.main_thread.unpark();
+            self.send_msg(MsgType::Info, self.format_msg(msg));
         }
     }
 
     fn error_msg(&mut self, msg: &CStr) {
         if let Ok(msg) = msg.to_str() {
-            let _ = self.msg_tx.send(Msg {
-                _type: MsgType::Error,
-                msg: self.format_msg(msg),
-            });
-            self.main_thread.unpark();
+            self.send_msg(MsgType::Error, self.format_msg(msg));
         }
     }
 }


### PR DESCRIPTION
Hey! As mentioned in #17, I've been using this for about a week with fingerprint-or-password on sudo, and made a few personal tweaks on top with a good amount of AI help (still learning Rust). Cleaned them up and figured I'd share in case any of it is useful, this is more "here's an idea" than an actual request for review.

Main thing: the password prompt now reads straight from /dev/tty so it can get cancelled the moment another method (e.g. fingerprint) succeeds, instead of sitting there waiting for Enter.

One heads up: I also ended up silencing the text_info/error_msg messages from sub-modules, which I know is different from what you set up on purpose in the rewrite — not saying that's the "right" call, just what worked better for my specific setup. Happy to talk through it or drop that part if it doesn't make sense to carry over.

Also fixed a few unsafe/FFI things I ran into while touching this code (SIGPIPE handling, Ctrl-C during raw-mode reads, fd cleanup on early returns) - details in the commit if useful.
